### PR TITLE
fix(ADHD-25): Fix supervisor routing to enforce single agent selection

### DIFF
--- a/src/adhd_planner/agents/supervisor.py
+++ b/src/adhd_planner/agents/supervisor.py
@@ -119,10 +119,19 @@ class SupervisorAgent(BaseAgent):
                 "direct_response",
             ]
 
-            if routing_decision["agent"] not in valid_agents:
+            agent_name = routing_decision["agent"]
+
+            # Handle pipe-separated agents (fallback safety)
+            if "|" in agent_name:
                 self.logger.warning(
-                    f"Invalid agent: {routing_decision['agent']}, defaulting to direct_response"
+                    f"LLM returned multiple agents: {agent_name}. Using first agent only."
                 )
+                agent_name = agent_name.split("|")[0].strip()
+                routing_decision["agent"] = agent_name
+
+            # Validate against valid agents list
+            if agent_name not in valid_agents:
+                self.logger.warning(f"Invalid agent: {agent_name}, defaulting to direct_response")
                 routing_decision["agent"] = "direct_response"
 
             return routing_decision

--- a/src/adhd_planner/utils/prompts/supervisor_prompts.py
+++ b/src/adhd_planner/utils/prompts/supervisor_prompts.py
@@ -4,28 +4,30 @@ SUPERVISOR_SYSTEM_PROMPT = """You are the Supervisor Agent for ADHD Planner, an 
 
 Your role is to:
 1. Understand user requests
-2. Route them to the appropriate specialist agent
+2. Route them to the appropriate specialist agent (ONE agent only)
 3. Synthesize responses when multiple agents are involved
 
 Available specialist agents:
-- **planning_agent**: Create, modify, or analyze tasks
+- **planning_agent**: Create, modify, or analyze tasks. Use for listing tasks, getting task details, creating/updating tasks.
 - **scheduling_agent**: Generate daily/weekly schedules, optimize time blocks
 - **suggestion_agent**: Recommend what to work on based on context
 - **sync_agent**: Sync with Apple Reminders/Calendar
 - **energy_agent**: Track and analyze energy patterns
 
 Routing guidelines:
-- Use planning_agent for: "add task", "create task", "update task", "task details"
-- Use scheduling_agent for: "plan my day", "schedule", "time blocks", "optimize schedule"
-- Use suggestion_agent for: "what should I do", "recommend", "what's next"
+- Use planning_agent for: "add task", "create task", "update task", "task details", "list tasks", "show tasks", "plan tasks", "plan these tasks", "help me plan"
+- Use scheduling_agent for: "plan my day", "schedule my day", "schedule my week", "time blocks", "optimize schedule", "when should I work on"
+- Use suggestion_agent for: "what should I do", "what should I work on", "recommend", "what's next", "suggest"
 - Use sync_agent for: "sync with apple", "sync reminders", "sync calendar"
 - Use energy_agent for: "log energy", "energy patterns", "when am I productive"
-- Use "direct_response" for: greetings, general questions, clarifications
+- Use "direct_response" for: greetings, general questions, clarifications, help requests
+
+IMPORTANT: You MUST select exactly ONE agent. Do not combine multiple agents or use pipe symbols (|).
 
 Respond in JSON format:
 {
   "intent": "description of what user wants",
-  "agent": "agent_name or direct_response",
+  "agent": "single_agent_name",
   "reasoning": "why you chose this agent",
   "needs_context": ["list", "of", "context", "needed"]
 }
@@ -43,7 +45,7 @@ def get_routing_prompt(user_input: str, conversation_history: str = "") -> str:
     Returns:
         Formatted prompt for LLM
     """
-    prompt = f"""Analyze this user request and determine which agent should handle it.
+    prompt = f"""Analyze this user request and determine which ONE agent should handle it.
 
 User request: "{user_input}"
 """
@@ -52,13 +54,35 @@ User request: "{user_input}"
         prompt += f"\nConversation context:\n{conversation_history}\n"
 
     prompt += """
-Respond with JSON only, following this format:
+Select the MOST APPROPRIATE agent from this list:
+- planning_agent
+- scheduling_agent
+- suggestion_agent
+- sync_agent
+- energy_agent
+- direct_response
+
+CRITICAL: Choose EXACTLY ONE agent. Do NOT use pipe symbols (|) or combine multiple agents.
+
+Respond with JSON only, following this EXACT format:
 {
   "intent": "what the user wants to accomplish",
-  "agent": "planning_agent|scheduling_agent|suggestion_agent|sync_agent|energy_agent|direct_response",
+  "agent": "one_agent_name_from_list_above",
   "reasoning": "explanation of routing decision",
   "needs_context": ["tasks", "calendar", "energy_patterns"]
 }
+
+Example valid responses:
+{"intent": "list all tasks", "agent": "planning_agent", "reasoning": "user wants to view tasks", "needs_context": ["tasks"]}
+{"intent": "plan my day", "agent": "scheduling_agent", "reasoning": "user wants daily schedule with time blocks", "needs_context": ["tasks", "calendar"]}
+{"intent": "plan tasks", "agent": "planning_agent", "reasoning": "user wants to create or organize tasks", "needs_context": ["tasks"]}
+{"intent": "create a task", "agent": "planning_agent", "reasoning": "user wants to add a new task", "needs_context": []}
+{"intent": "what should I work on", "agent": "suggestion_agent", "reasoning": "user wants recommendations on next task", "needs_context": ["tasks", "calendar", "energy_patterns"]}
+
+Key distinctions:
+- "plan tasks" or "plan these tasks" → planning_agent (task creation/organization)
+- "plan my day/week" or "schedule" → scheduling_agent (time blocking and optimization)
+- "what should I do" → suggestion_agent (recommendations based on context)
 """
 
     return prompt


### PR DESCRIPTION
## Summary

Fixes #25 - Supervisor agent now correctly handles routing decisions by enforcing single agent selection and preventing pipe-separated agent responses from the LLM.

## Problem

The supervisor agent was receiving routing decisions with pipe-separated agents (e.g., `planning_agent|scheduling_agent`) from the LLM, causing:
- Invalid agent warnings
- Fallback to `direct_response`
- Immediate routing to `END` without executing the appropriate agent
- User queries like "list all tasks" and "plan tasks" failing silently

## Solution

Implemented a two-pronged approach:

### 1. Enhanced LLM Prompts (Primary Fix)
- **System Prompt**: Added explicit "ONE agent only" instruction
- **Routing Prompt**: 
  - Clearer language: "which ONE agent" instead of "which agent"
  - Removed confusing pipe-separated format from examples
  - Added explicit warning: "Do NOT use pipe symbols (|)"
  - Added multiple concrete examples of valid responses
  - Added key distinctions between agent types
  - Improved routing guidelines with more query patterns

### 2. Fallback Safety Logic (Defensive Programming)
Added pipe-separated agent handler in [supervisor.py:125-130](https://github.com/Ashish-Surve/genai-agent-planner/blob/fix/ADHD-25-supervisor-routing-fix/src/adhd_planner/agents/supervisor.py#L125-L130):
- Detects pipe-separated agents
- Logs warning
- Extracts first agent from the list
- Continues with validation

## Changes Made

### Modified Files

1. **`src/adhd_planner/utils/prompts/supervisor_prompts.py`**
   - Updated `SUPERVISOR_SYSTEM_PROMPT` with explicit single-agent instruction
   - Enhanced `get_routing_prompt()` with:
     - Clearer agent selection instructions
     - Explicit list format instead of pipe-separated
     - 5 concrete example responses
     - Key distinctions between agent types
   - Added routing patterns for "plan tasks" → `planning_agent`

2. **`src/adhd_planner/agents/supervisor.py`**
   - Added pipe-separated agent detection and handling
   - Improved logging for better debugging
   - Maintained backward compatibility

## Test Plan

- [x] Test "list all tasks" → should route to `planning_agent`
- [x] Test "plan tasks" → should route to `planning_agent`
- [x] Test "plan my day" → should route to `scheduling_agent`
- [x] Test "what should I do" → should route to `suggestion_agent`
- [x] Verify no pipe-separated agents in routing decisions
- [x] Verify fallback logic handles edge cases
- [ ] Run full integration test suite (to be done by reviewer)

## Impact

- **User Impact**: Fixes broken task listing and planning functionality
- **Performance**: No performance impact
- **Breaking Changes**: None
- **Backward Compatibility**: Fully maintained

## Additional Notes

The prompt improvements follow best practices for LLM instruction:
- Clear, explicit constraints
- Concrete examples
- Structured format requirements
- Negative instructions (what NOT to do)

The fallback logic provides defense-in-depth in case the LLM still returns unexpected formats.

## Related

- Closes #25
- Related to ADHD-12 (Supervisor Agent implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>